### PR TITLE
Resolving Issue 12 - Clarify Legacy point counts for PDRF 6-10

### DIFF
--- a/source/01_intro.txt
+++ b/source/01_intro.txt
@@ -48,10 +48,11 @@ Summary of LAS 1.4 revisions:
     * Swapped order of LAS 1.4 Revision History (now s1.1.1) and
       LAS 1.4 Additions (now s1.1.2).
 
-  * Changed type of ExtraByte min/max from ``anytype`` to ``double``.
+  * Changed type of ExtraByte min/max from ``anytype`` to ``double`` and
+    clarified that min/max should be a transformed value.
     (`I-4 <https://github.com/ASPRSorg/LAS/issues/4>`_)
-
-    * Clarified ExtraByte min/max should be a transformed value.
+  * Clarified that Legacy Point Counts should be set to zero if using non-legacy
+    PDRFs. (`I-12 <https://github.com/ASPRSorg/LAS/issues/12>`_)
 
 For detailed information on changes in revisions R14 and newer, review the
 inline differencing provided on the GitHub page: https://github.com/ASPRSorg/LAS

--- a/source/02.04_header.txt
+++ b/source/02.04_header.txt
@@ -280,17 +280,20 @@ described with an Extra Bytes VLR (see Table 24 and Table 25).
 **Legacy Number of point records**
 
 This field contains the total number of point records within the file if the
-file is maintaining legacy compatibility and the number of points is no greater
-than UINT32_MAX. It must be zero otherwise.
+file is maintaining legacy compatibility, the number of points is no greater
+than UINT32_MAX, and the Point Data Record Format is less than 6. It must be
+set to zero otherwise.
 
 **Legacy Number of points by return**
 
 These fields contain an array of the total point records per return if the file
-is maintaining legacy compatibility and the number of points is no greater than
-UINT32_MAX. The first value will be the total number of records from the first
+is maintaining legacy compatibility, the number of points is no greater than
+UINT32_MAX, and the Point Data Record Format is less than 6. Otherwise, each
+member of the array must be set to zero.
+
+The first value will be the total number of records from the first
 return, the second contains the total number for return two, and so on up to
-five returns. If the file is not maintaining legacy compatibility, each member
-of the array must be set to zero.
+five returns.
 
 **X, Y, and Z scale factors**
 


### PR DESCRIPTION
Simple change in LAS header description to clarify that maintaining legacy compatibility does not include using the new PDRFs.

Closes #12.