### PR TITLE
Resolving Issue 46 - Clarify null-termination of fixed-length char

### DIFF
--- a/source/01_intro.txt
+++ b/source/01_intro.txt
@@ -57,6 +57,8 @@ Summary of LAS 1.4 revisions:
     PDRFs. (`I-12 <https://github.com/ASPRSorg/LAS/issues/12>`_)
   * PDRF9 now correctly requires Scanner Channel like other PDRFs.
     (`I-29 <https://github.com/ASPRSorg/LAS/issues/29>`_)
+  * Clarified null-termination of fixed-length ``char`` arrays, especially VLR
+    Description. (`I-46 <https://github.com/ASPRSorg/LAS/issues/46>`_)
 
 For detailed information on changes in revisions R14 and newer, review the
 inline differencing provided on the GitHub page: https://github.com/ASPRSorg/LAS

--- a/source/02.03_datatypes.sub
+++ b/source/02.03_datatypes.sub
@@ -15,6 +15,17 @@ data types are conformant to the 1999 ANSI C Language Specification
 * unsigned long long (8 bytes)
 * float (4 byte IEEE floating point format)
 * double (8 byte IEEE floating point format)
-* string (a variable series of 1 byte characters, ASCII encoded, null terminated)
+* string (a variable series of 1 byte characters, ASCII encoded, null-terminated)
 
+.. warning::
+
+    Fixed-length ``char`` arrays will not be null-terminated if all bytes are
+    utilized. Examples include the System Identifier and Generating Software in
+    the LAS Header, the User ID or Description in the Variable Length Record,
+    and the Name of an Extra Byte Descriptor.
+
+
+.. raw:: latex
+
+    \newpage
 

--- a/source/02.05_vlr.sub
+++ b/source/02.05_vlr.sub
@@ -61,7 +61,7 @@ of the record.
 
 **Description**
 
-Optional, null terminated text description of the data. Any remaining
+Optional text description of the data. Any remaining
 characters not used must be null.
 
 .. raw:: latex

--- a/source/04_optional_vlrs.txt
+++ b/source/04_optional_vlrs.txt
@@ -34,7 +34,7 @@ Text Area Description
 +-----------------+-----------------------------+
 
 This VLR/EVLR is used for providing a textual description of the content of the
-LAS file. It is a null terminated, free-form ASCII string.
+LAS file. It is a null-terminated, free-form ASCII string.
 
 Extra Bytes
 ................................................................................


### PR DESCRIPTION
Clarified null-termination throughout spec. Fixed-length `char` arrays don't have to be null-terminated, but free-form strings do. I think that's always been the case, but the VLR Description claimed to be null-terminated. That tells me that this could potentially break a VLR reader that took the spec at face value. However, no other `char` arrays said this and it seems like a waste of a character.

@ASPRSorg/lwg Will this break anyone's software?

Resolves #46 