### PR TITLE
Resolving Issue 59 - Clarify FileSourceID and PointSourceID

### DIFF
--- a/source/01_intro.txt
+++ b/source/01_intro.txt
@@ -59,6 +59,8 @@ Summary of LAS 1.4 revisions:
     (`I-29 <https://github.com/ASPRSorg/LAS/issues/29>`_)
   * Clarified origin date/time for Adjusted Standard GPS Time.
     (`I-40 <https://github.com/ASPRSorg/LAS/issues/40>`_)
+  * Clarified relationship between FileSourceID and PointSourceID.
+    (`I-59 <https://github.com/ASPRSorg/LAS/issues/59>`_)
 
 For detailed information on changes in revisions R14 and newer, review the
 inline differencing provided on the GitHub page: https://github.com/ASPRSorg/LAS

--- a/source/02.04_header.sub
+++ b/source/02.04_header.sub
@@ -102,13 +102,15 @@ as a quick look initial determination of file type.
 
 **File Source ID**
 
-This field should be set to a value ranging from 1 to 65,535. If this file was
-derived from an original flight line, this is often the flight line number. A
-value of zero (0) is interpreted to mean that an ID has not been assigned. In
-this case, processing software is free to assign a number. Note that this
-scheme allows a LIDAR project to contain up to 65,535 unique sources. A source
-can be an original flight line or it can be result of merge and/or extract
-operations.
+This field should be set to a value from 0 to 65,535. A value of zero is
+interpreted to mean that an ID has not been assigned, which is the norm for a
+LAS file resulting from a merge operation such as a tile.
+
+Note that this scheme allows a project to contain up to 65,535 unique sources.
+Example sources can include a data repository ID or an original collection such
+as a flight line for direct measurement airborne systems, a route number for
+mobile systems, or a setup identifier for static systems.
+
 
 .. _globalencoding_link:
 

--- a/source/02.06_point.sub
+++ b/source/02.06_point.sub
@@ -232,14 +232,17 @@ This field may be used at the user's discretion.
 
 **Point Source ID**
 
-This value indicates the file from which this point originated. Valid values
-for this field are 1 to 65,535 inclusive with zero being used for a special
-case discussed below. The numerical value corresponds to the File Source ID
-from which this point originated. Zero is reserved as a convenience to system
-implementers. A Point Source ID of zero implies that this point originated in
-this file. This implies that processing software should set the Point Source ID
-equal to the File Source ID of the file containing this point at some time
-during processing.
+This value indicates the source from which this point originated, such as a
+swath number for conventional airborne systems, a route number for mobile
+systems, or a setup identifier for static systems. For a LAS file created during
+a merge operation, the Point Source ID could equal the File Source ID of the
+origin LAS file.
+
+Valid values for this field are 1 to 65,535 inclusive. Zero is reserved as a
+convenience to system implementers. A Point Source ID of zero implies that this
+point originated in this file, such as for a Synthetic point, or is derived from
+multiple sources.
+
 
 .. raw:: latex
 


### PR DESCRIPTION
The relationship between FileSourceID and PtSourceID needed clarifying, especially for non-lidar or non-linear systems.

Resolves #59.