### PR TITLE
Add issue templates

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ['https://www.asprsfoundation.org/donate']

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: true
+contact_links:
+- name: How to contribute
+  url: https://github.com/ASPRSorg/LAS/wiki/Get-Involved
+  about: Learn how to participate in the ASPRS LAS Committee
+- name: ASPRS LiDAR Division
+  url: https://www.asprs.org/divisions-committees/lidar-division
+  about: Visit the LiDAR Division homepage
+

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,0 +1,19 @@
+name: Issue
+description: A standard issue or inquiry about the ASPRS LAS specification
+body:
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What is the issue about?
+      multiple: true
+      options:
+        - Software implementation
+        - Inquiry about the specification
+        - Committee efforts
+  - type: textarea
+    id: buginfo
+    attributes:
+      label: Issue description
+      description: Describe the issue or question
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -10,6 +10,7 @@ body:
         - Software implementation
         - Inquiry about the specification
         - Committee efforts
+        - Other
   - type: textarea
     id: buginfo
     attributes:

--- a/.github/ISSUE_TEMPLATE/vlr.yml
+++ b/.github/ISSUE_TEMPLATE/vlr.yml
@@ -1,0 +1,50 @@
+name: Variable Length Record Community Description
+description: Describe a VLR in use in the community
+title: "[VLR Description]: "
+labels: ["vlr"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please enter a description of a community LAS VLR
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: Who knows about this VLR and could answer questions about it?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: user_id
+    attributes:
+      label: LAS User ID
+      description: The LAS User ID in use for this VLR
+    validations:
+      required: true
+  - type: checkboxes
+    id: is_registered
+    attributes:
+      label: User ID registration
+      description: Is the LAS User ID registered with the [ASPRS VLR Key List](https://www.asprs.org/misc/las-key-list.html).
+      options:
+        - label: Registered?
+  - type: textarea
+    id: record_id
+    attributes:
+      label: LAS Record ID
+      description: The LAS Record ID in use for this VLR
+    validations:
+      required: true
+  - type: textarea
+    id: application
+    attributes:
+      label: What application(s) is the VLR used with?
+  - type: textarea
+    id: usage
+    attributes:
+      label: Please describe what the VLR is used for
+  - type: textarea
+    id: definition
+    attributes:
+      label: Please provide a definition of the VLR's contents

--- a/.github/ISSUE_TEMPLATE/vlr.yml
+++ b/.github/ISSUE_TEMPLATE/vlr.yml
@@ -15,7 +15,7 @@ body:
       placeholder: ex. email@example.com
     validations:
       required: false
-  - type: textarea
+  - type: input
     id: user_id
     attributes:
       label: LAS User ID
@@ -29,7 +29,7 @@ body:
       description: Is the LAS User ID registered with the [ASPRS VLR Key List](https://www.asprs.org/misc/las-key-list.html).
       options:
         - label: Registered?
-  - type: textarea
+  - type: input
     id: record_id
     attributes:
       label: LAS Record ID


### PR DESCRIPTION
This PR adds issue templates for a standard issue and a VLR entry. My plan is to solicit the community to make tickets with VLR info and collate this into a document with some automation.

You can see the example templates in action in my fork at https://github.com/hobu/ASPRSORGLAS/issues/new/choose