### PR TITLE
Added Min/Max GPS Time to header block

### DIFF
--- a/source/01_intro.txt
+++ b/source/01_intro.txt
@@ -16,6 +16,25 @@ This document reflects the fourth revision of the LAS format specification
 since its initial version 1.0 release.
 
 
+LAS 1.5 Revision History
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Summary of LAS 1.5 revisions (GitHub Issue numbers included when applicable):
+
+* R00 - Approved Version (XXXXXXX).
+
+
+Comparison of LAS 1.5 to Previous Versions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The additions of LAS 1.5 include:
+
+* Backward compatibility with LAS 1.1 – LAS 1.4.
+* LAS 1.5 mode which supports:
+
+  * Added Max/Min GPS Time fields to header block.
+    (`I-118 <https://github.com/ASPRSorg/LAS/issues/118>`_)
+
 LAS 1.4 Revision History
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/02.04_header.sub
+++ b/source/02.04_header.sub
@@ -402,7 +402,7 @@ generally) GPS Time values stored with the point records in this LAS file. The
 GPS Time in this field will be in the same encoding described in the file's
 :ref:`Global Encoding <globalencoding_link>` field.
 
-If there are no points records in the file, these values must be set to zero.
-
-For :ref:`Aggregate Model Systems <aggregate_link>` or LAS files not utilizing
-GPS Time, these values must be set to zero.
+These values must be set to zero if there are no point records in the file,
+if the file utilizes a point record format not supporting GPS Time, or if
+all point records within the file have GPS Time values set to zero,
+such as for certain :ref:`Aggregate Model Systems <aggregate_link>`.

--- a/source/02.04_header.sub
+++ b/source/02.04_header.sub
@@ -385,9 +385,7 @@ intent.
 .. note::
 
     Any changes to the number of points or their attributes must also be reflected
-	in the Public Header Block.
-
-
+    in the Public Header Block.
 
 **Number of Points by Return**
 

--- a/source/02.04_header.sub
+++ b/source/02.04_header.sub
@@ -350,8 +350,6 @@ The max and min data fields are the actual unscaled extents of the LAS point
 file data, specified in the coordinate system of the LAS data. If there are no
 point records in the file, these values must be set to zero.
 
-Any changes to the point records must be re
-
 **Start of Waveform Data Packet Record**
 
 This value provides the offset, in bytes, from the beginning of the LAS file to

--- a/source/02.04_header.sub
+++ b/source/02.04_header.sub
@@ -87,6 +87,12 @@ Public Header Block
     +----------------------------------+-------------------------+-----------------+-----------+--------------+
     | Number of Points by Return       | uint64_t[15]            | 255             | 120 bytes | yes          |
     +----------------------------------+-------------------------+-----------------+-----------+--------------+
+    | Max GPS Time                     | double                  | 375             | 8 bytes   |              |
+    +----------------------------------+-------------------------+-----------------+-----------+--------------+
+    | Min GPS Time                     | double                  | 383             | 8 bytes   |              |
+    +----------------------------------+-------------------------+-----------------+-----------+--------------+
+    | *LAS 1.5 Header Size*                                      | *391 bytes*                                |
+    +------------------------------------------------------------+--------------------------------------------+
 
 .. note::
 
@@ -197,8 +203,8 @@ file can be uniquely identified, globally.
 
 The version number consists of a major and minor field. The major and minor
 fields combine to form the number that indicates the format number of the
-current specification itself. For example, specification number 1.4 would
-contain 1 in the major field and 4 in the minor field. It should be noted that
+current specification itself. For example, specification number 1.5 would
+contain 1 in the major field and 5 in the minor field. It should be noted that
 the LAS Working Group does not associate any particular meaning to major or
 minor version number.
 
@@ -257,8 +263,8 @@ The year, expressed as a four digit number, in which the file was created.
 
 **Header Size**
 
-The size, in bytes, of the Public Header Block itself. For LAS 1.4 this size is
-375 bytes. In the event that the header is extended by a new revision of the
+The size, in bytes, of the Public Header Block itself. For LAS 1.5 this size is
+391 bytes. In the event that the header is extended by a new revision of the
 LAS specification through the addition of data at the end of the header, the
 Header Size field will be updated with the new header size. The Public Header
 Block may not be extended by users.
@@ -344,6 +350,8 @@ The max and min data fields are the actual unscaled extents of the LAS point
 file data, specified in the coordinate system of the LAS data. If there are no
 point records in the file, these values must be set to zero.
 
+Any changes to the point records must be re
+
 **Start of Waveform Data Packet Record**
 
 This value provides the offset, in bytes, from the beginning of the LAS file to
@@ -376,6 +384,13 @@ This field contains the total number of point records in the file. Note that
 this field must always be correctly populated, regardless of legacy mode
 intent.
 
+.. note::
+
+    Any changes to the number of points or their attributes must also be reflected
+	in the Public Header Block.
+
+
+
 **Number of Points by Return**
 
 These fields contain an array of the total point records per return. The first
@@ -384,3 +399,14 @@ contains the total number for return two, and so on up to fifteen returns. Note
 that these fields must always be correctly populated, regardless of legacy mode
 intent.
 
+**Max and Min GPS Time**
+
+The max and min GPS Time fields reflect the highest and lowest valid (non-zero,
+generally) GPS Time values stored with the point records in this LAS file. The
+GPS Time in this field will be in the same encoding described in the file's
+:ref:`Global Encoding <globalencoding_link>` field.
+
+If there are no points records in the file, these values must be set to zero.
+
+For :ref:`Aggregate Model Systems <aggregate_link>` or LAS files not utilizing
+GPS Time, these values must be set to zero.

--- a/source/conf.py
+++ b/source/conf.py
@@ -56,7 +56,7 @@ author = u'ASPRS'
 # The short X.Y version.
 #version = u'1.4'
 # Custom non-keyword version tag for header
-myversion = u'1.4 - R16 DRAFT'
+myversion = u'1.5 - R20 DRAFT'
 # The full version, including alpha/beta/rc tags.
 release = u'VERSION ' + myversion
 releasename = release


### PR DESCRIPTION
Began work on LAS 1.5 introductory sections. (#131)
Added Min/Max GPS Time to header block. (#118)