### PR TITLE
Font fixes for fixed-width (code) rendering

### DIFF
--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -19,6 +19,8 @@ jobs:
       run: |
           python3 --version
           sphinx-build --version
+          DEBIAN_FRONTEND=noninteractive apt-get update  -y
+          DEBIAN_FRONTEND=noninteractive apt-get install texlive-fonts-recommended -y
     - name: Lint .rst files
       run: |
         if find . -name '*.rst' | xargs grep -P '\t'; then echo 'Tabs are bad, please use four spaces in .rst files.'; false; fi

--- a/source/conf.py
+++ b/source/conf.py
@@ -136,6 +136,8 @@ preamble = r'''
 
 \usepackage{titling}
 \usepackage{fancyhdr}
+\usepackage{times}
+\usepackage{courier}
 \makeatletter
 \fancypagestyle{normal}{
     \fancyhf{}
@@ -249,7 +251,7 @@ latex_elements = {
 
     # The font size ('10pt', '11pt' or '12pt').
     #
-    'pointsize': '12pt',
+    'pointsize': '11pt',
 
     # Other document class options - ensure uniform header/footer
     'classoptions': ',oneside,openany',


### PR DESCRIPTION
Add missing Courier font
Make Times font explicit.
Reduce font size from 12pt to 11pt

Credit: @hobu for doing ALL of the work. All I did was squash his commits and make it compatible with LAS 1.4.